### PR TITLE
docs: fix broken script references in subagent.md

### DIFF
--- a/docs/subagent.md
+++ b/docs/subagent.md
@@ -15,25 +15,23 @@ read_when:
   ```
 
   Once inside the session, run `/model` to confirm the active alias (`haiku` maps to Claude 3.5 Haiku) and switch models if needed.
-- Need to queue instructions without attaching? Use `bun scripts/agent-send.ts --session <name> -- "your command"` to inject text into a running agent session (single Enter is sent by default).
+- Need to queue instructions without attaching? Use `tmux send-keys -t <session> "your command" Enter` to inject text into a running agent session.
 - Always switch to the fast Haiku model upfront (`claude --model haiku --dangerously-skip-permissions …` or `/model haiku` in-session) to keep turnaround fast.
 - Two modes:
   - **One-shot tasks** (single summary, short answer): run `claude --model haiku --dangerously-skip-permissions --print …` in a tmux session, wait with `sleep 30`, then read the output buffer.
   - **Interactive tasks** (multi-file edits, iterative prompts): start `claude --model haiku --dangerously-skip-permissions` in tmux, send prompts with `tmux send-keys`, and capture completed responses with `tmux capture-pane`. Expect to sleep between turns so Haiku can finish before you scrape the pane.
-- Ralph’s supervisor loop launches Claude the same way (`claude --dangerously-skip-permissions "<prompt>"`) to keep the tmux automation flowing.
-
 ## One-Shot Prompts
 - The CLI accepts the prompt as a trailing argument in one-shot mode. Multi-line prompts can be piped: `echo "..." | claude --print`.
 - Add `--output-format json` when you need structured fields (e.g., summary + bullets) for post-processing.
-- Keep prompts explicit about reading full files: “Read docs/example.md in full and produce a 2–3 sentence summary covering all sections.”
+- Keep prompts explicit about reading full files: "Read docs/example.md in full and produce a 2-3 sentence summary covering all sections."
 
 ## Bulk Markdown Conversion
 - Produce the markdown inventory first (`pnpm run docs:list`) and feed batches of filenames to your Claude session.
-- For each batch, issue a single instruction like “Rewrite these files with YAML front matter summaries, keep all other content verbatim.” Haiku can loop over multi-file edits when you provide the explicit list.
+- For each batch, issue a single instruction like "Rewrite these files with YAML front matter summaries, keep all other content verbatim." Haiku can loop over multi-file edits when you provide the explicit list.
 - After Claude reports success, diff each file locally (`git diff docs/<file>.md`) before moving to the next batch.
 
-## Ralph Integration Notes
-- Ralph (see `scripts/ralph.ts`) spins up tmux sessions, auto-wakes the worker, and calls Claude as the supervisor via `claude --dangerously-skip-permissions`.
-- Supervisor responses must end with either `CONTINUE`, `SEND: <message>`, or `RESTART`; Ralph parses these tokens to decide the next action.
-- To start Ralph manually: `bun scripts/ralph.ts start --goal "…" [--markdown path]`. Progress is tracked in `.ralph/progress.md` by default.
-- Send ad-hoc instructions to the worker session with `bun scripts/ralph.ts send-to-worker -- "your guidance"`.
+## Supervisor Loop Pattern
+- A supervisor loop can spin up tmux sessions, auto-wake workers, and call Claude via `claude --dangerously-skip-permissions "<prompt>"` to keep tmux automation flowing.
+- Supervisor responses typically end with tokens like `CONTINUE`, `SEND: <message>`, or `RESTART` so the orchestrator can decide the next action.
+- Progress can be tracked in a local file (e.g., `.ralph/progress.md`) by default.
+- Send ad-hoc instructions to a worker session with `tmux send-keys -t <worker-session> "your guidance" Enter`.


### PR DESCRIPTION
## Summary

`docs/subagent.md` referenced two scripts that don't exist in the repo:
- `scripts/agent-send.ts` (line 18)
- `scripts/ralph.ts` (lines 23, 36-39)

## Changes

- **Replaced `agent-send.ts` reference** with the equivalent `tmux send-keys` command, which achieves the same result without an external script.
- **Removed the dangling Ralph supervisor bullet** from CLI Basics.
- **Renamed "Ralph Integration Notes" → "Supervisor Loop Pattern"** and generalized the section to describe the pattern without referencing the non-existent script. The guidance (supervisor tokens, progress tracking, worker messaging) is preserved.

Fixes #6