### PR TITLE
feat: migrate nano banana skill to Gemini 3.1 Flash Image Preview

### DIFF
--- a/scripts/nanobanana
+++ b/scripts/nanobanana
@@ -4,7 +4,7 @@
 # dependencies = ["google-genai", "Pillow"]
 # ///
 """
-nanobanana - Image editing with Gemini's Nano Banana Pro API
+nanobanana - Image editing with Gemini's Nano Banana 2 API
 Usage: nanobanana <image-path> "<prompt>" [output-path]
 
 Examples:
@@ -46,12 +46,12 @@ def edit_image(image_path: str, prompt: str, output_path: str | None = None) -> 
         base, ext = os.path.splitext(image_path)
         output_path = f"{base}_edited{ext}"
 
-    print(f"🍌 Sending to Nano Banana Pro...")
+    print(f"🍌 Sending to Nano Banana 2...")
     print(f"   Prompt: {prompt}")
 
     try:
         response = client.models.generate_content(
-            model="gemini-2.5-flash-image",
+            model="gemini-3.1-flash-image-preview",
             contents=[prompt, image],
             config=genai.types.GenerateContentConfig(response_modalities=["TEXT", "IMAGE"]),
         )

--- a/skills/nano-banana-pro/SKILL.md
+++ b/skills/nano-banana-pro/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: nano-banana-pro
-description: Generate/edit images with Nano Banana Pro (Gemini 3 Pro Image). Use for image create/modify requests incl. edits. Supports text-to-image + image-to-image; 1K/2K/4K; use --input-image.
+description: Generate/edit images with Nano Banana 2 (Gemini 3.1 Flash Image Preview). Use for image create/modify requests incl. edits. Supports text-to-image + image-to-image; 1K/2K/4K; use --input-image.
 ---
 
-# Nano Banana Pro Image Generation & Editing
+# Nano Banana 2 Image Generation & Editing
 
-Generate new images or edit existing ones using Google's Nano Banana Pro API (Gemini 3 Pro Image).
+Generate new images or edit existing ones using Google's Nano Banana 2 API (Gemini 3.1 Flash Image Preview).
 
 ## Usage
 
@@ -36,7 +36,7 @@ Goal: fast iteration without burning time on 4K until the prompt is correct.
 
 ## Resolution Options
 
-The Gemini 3 Pro Image API supports three resolutions (uppercase K required):
+The Gemini 3.1 Flash Image Preview API supports three resolutions (uppercase K required):
 
 - **1K** (default) - ~1024px resolution
 - **2K** - ~2048px resolution

--- a/skills/nano-banana-pro/SKILL.md
+++ b/skills/nano-banana-pro/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nano-banana-pro
-description: Generate/edit images with Nano Banana 2 (Gemini 3.1 Flash Image Preview). Use for image create/modify requests incl. edits. Supports text-to-image + image-to-image; 1K/2K/4K; use --input-image.
+description: Generate/edit images with Nano Banana 2 (Gemini 3.1 Flash Image Preview). Use for image create/modify requests incl. edits. Supports text-to-image + image-to-image; 0.5K/1K/2K/4K; use --input-image.
 ---
 
 # Nano Banana 2 Image Generation & Editing
@@ -13,12 +13,12 @@ Run the script using absolute path (do NOT cd to skill directory first):
 
 **Generate new image:**
 ```bash
-uv run ~/.codex/skills/nano-banana-pro/scripts/generate_image.py --prompt "your image description" --filename "output-name.png" [--resolution 1K|2K|4K] [--api-key KEY]
+uv run ~/.codex/skills/nano-banana-pro/scripts/generate_image.py --prompt "your image description" --filename "output-name.png" [--resolution 0.5K|1K|2K|4K] [--api-key KEY]
 ```
 
 **Edit existing image:**
 ```bash
-uv run ~/.codex/skills/nano-banana-pro/scripts/generate_image.py --prompt "editing instructions" --filename "output-name.png" --input-image "path/to/input.png" [--resolution 1K|2K|4K] [--api-key KEY]
+uv run ~/.codex/skills/nano-banana-pro/scripts/generate_image.py --prompt "editing instructions" --filename "output-name.png" --input-image "path/to/input.png" [--resolution 0.5K|1K|2K|4K] [--api-key KEY]
 ```
 
 **Important:** Always run from the user's current working directory so images are saved where the user is working, not in the skill directory.
@@ -36,13 +36,15 @@ Goal: fast iteration without burning time on 4K until the prompt is correct.
 
 ## Resolution Options
 
-The Gemini 3.1 Flash Image Preview API supports three resolutions (uppercase K required):
+The Gemini 3.1 Flash Image Preview API supports these resolutions (uppercase K required):
 
+- **0.5K** - ~512px resolution
 - **1K** (default) - ~1024px resolution
 - **2K** - ~2048px resolution
 - **4K** - ~4096px resolution
 
 Map user requests to API parameters:
+- "512", "512px", "0.5K", "thumbnail", "tiny" → `0.5K`
 - No mention of resolution → `1K`
 - "low resolution", "1080", "1080p", "1K" → `1K`
 - "2K", "2048", "normal", "medium resolution" → `2K`

--- a/skills/nano-banana-pro/scripts/generate_image.py
+++ b/skills/nano-banana-pro/scripts/generate_image.py
@@ -10,7 +10,7 @@
 Generate images using Google's Nano Banana 2 (Gemini 3.1 Flash Image Preview) API.
 
 Usage:
-    uv run generate_image.py --prompt "your image description" --filename "output.png" [--resolution 1K|2K|4K] [--api-key KEY]
+    uv run generate_image.py --prompt "your image description" --filename "output.png" [--resolution 0.5K|1K|2K|4K] [--api-key KEY]
 """
 
 import argparse
@@ -46,9 +46,9 @@ def main():
     )
     parser.add_argument(
         "--resolution", "-r",
-        choices=["1K", "2K", "4K"],
+        choices=["0.5K", "1K", "2K", "4K"],
         default="1K",
-        help="Output resolution: 1K (default), 2K, or 4K"
+        help="Output resolution: 0.5K, 1K (default), 2K, or 4K"
     )
     parser.add_argument(
         "--api-key", "-k",

--- a/skills/nano-banana-pro/scripts/generate_image.py
+++ b/skills/nano-banana-pro/scripts/generate_image.py
@@ -7,7 +7,7 @@
 # ]
 # ///
 """
-Generate images using Google's Nano Banana Pro (Gemini 3 Pro Image) API.
+Generate images using Google's Nano Banana 2 (Gemini 3.1 Flash Image Preview) API.
 
 Usage:
     uv run generate_image.py --prompt "your image description" --filename "output.png" [--resolution 1K|2K|4K] [--api-key KEY]
@@ -28,7 +28,7 @@ def get_api_key(provided_key: str | None) -> str | None:
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Generate images using Nano Banana Pro (Gemini 3 Pro Image)"
+        description="Generate images using Nano Banana 2 (Gemini 3.1 Flash Image Preview)"
     )
     parser.add_argument(
         "--prompt", "-p",
@@ -112,7 +112,7 @@ def main():
 
     try:
         response = client.models.generate_content(
-            model="gemini-3-pro-image-preview",
+            model="gemini-3.1-flash-image-preview",
             contents=contents,
             config=types.GenerateContentConfig(
                 response_modalities=["TEXT", "IMAGE"],


### PR DESCRIPTION
## Summary
This PR updates the Nano Banana skill/scripts to use the newly released Nano Banana 2 model.

### Changes
- Switched `skills/nano-banana-pro/scripts/generate_image.py` model ID from `gemini-3-pro-image-preview` to `gemini-3.1-flash-image-preview`.
- Updated `scripts/nanobanana` model ID from `gemini-2.5-flash-image` to `gemini-3.1-flash-image-preview`.
- Added support for `0.5K` (~512px) output resolution in `skills/nano-banana-pro/scripts/generate_image.py`.
- Updated user-facing docs/text from "Nano Banana Pro / Gemini 3 Pro Image" to "Nano Banana 2 / Gemini 3.1 Flash Image Preview" in:
  - `skills/nano-banana-pro/SKILL.md`
  - `skills/nano-banana-pro/scripts/generate_image.py`
  - `scripts/nanobanana`
- Updated skill usage/resolution documentation to include `0.5K` / 512px mappings.

## Verification
- `uv run skills/nano-banana-pro/scripts/generate_image.py --help` (passes; now includes `--resolution {0.5K,1K,2K,4K}`)
- `uv run skills/nano-banana-pro/scripts/generate_image.py --prompt "simple black circle on white background" --filename "/tmp/nano-banana-2-smoke.png" --resolution 1K` (passes)
- `uv run skills/nano-banana-pro/scripts/generate_image.py --prompt "simple black circle on white background" --filename "/tmp/nano-banana-2-0.5k-smoke.png" --resolution 0.5K` (passes)
- `uv run scripts/nanobanana` (shows usage text with updated model naming)
- `python3 -m py_compile skills/nano-banana-pro/scripts/generate_image.py scripts/nanobanana` (passes)

## Context / Sources
- Gemini API release notes (Feb 26, 2026): Nano Banana 2 launch (`Gemini 3.1 Flash Image Preview`) and March 9 shutdown notice for `gemini-3-pro-preview`:
  - https://ai.google.dev/gemini-api/docs/changelog
- Gemini 3.1 Flash Image model page (model ID + image sizes, including `0.5K`):
  - https://ai.google.dev/gemini-api/docs/models/gemini-3.1-flash-image-preview
- Deprecations page showing March 9 shutdown applies to `gemini-3-pro-preview`:
  - https://ai.google.dev/gemini-api/docs/deprecations
