### PR TITLE
feat: add network command to browser-tools

### DIFF
--- a/scripts/browser-tools.ts
+++ b/scripts/browser-tools.ts
@@ -16,7 +16,7 @@ import path from 'node:path';
 import readline from 'node:readline/promises';
 import { stdin as input, stdout as output } from 'node:process';
 import { inspect } from 'node:util';
-import puppeteer from 'puppeteer-core';
+import puppeteer, { type HTTPRequest } from 'puppeteer-core';
 
 /** Utility type so TypeScript knows the async function constructor */
 type AsyncFunctionCtor = new (...args: string[]) => (...fnArgs: unknown[]) => Promise<unknown>;
@@ -573,6 +573,129 @@ program
         // One-shot mode with timeout
         const duration = timeout ?? 5;
         console.log(gray(`Capturing console logs for ${duration} seconds...`));
+        await new Promise((resolve) => setTimeout(resolve, duration * 1000));
+      }
+    } finally {
+      await browser.disconnect();
+    }
+  });
+
+program
+  .command('network')
+  .description('Capture network requests from the active tab from attach time; websocket shows only the upgrade handshake.')
+  .option('--port <number>', 'Debugger port (default: 9222)', (value) => Number.parseInt(value, 10), DEFAULT_PORT)
+  .option('--types <list>', 'Comma-separated resource types (e.g., xhr,fetch,document). Default: all')
+  .option('--follow', 'Continuous monitoring mode (like tail -f)', false)
+  .option('--timeout <seconds>', 'Capture duration in seconds (default: 5 for one-shot, infinite for --follow)', (value) => Number.parseInt(value, 10))
+  .option('--color', 'Force color output')
+  .option('--no-color', 'Disable color output')
+  .action(async (options) => {
+    const port = options.port as number;
+    const follow = options.follow as boolean;
+    const timeout = options.timeout as number | undefined;
+    const typesFilter = options.types as string | undefined;
+
+    // Track explicit color flags by looking at argv to avoid Commander defaults overriding TTY detection.
+    const argv = process.argv.slice(2);
+    const colorFlag = argv.includes('--color') ? true : argv.includes('--no-color') ? false : undefined;
+
+    // Determine if we should use colors: explicit flag or TTY auto-detection
+    const useColor = colorFlag ?? process.stdout.isTTY;
+
+    const allowedTypes = typesFilter
+      ? new Set(typesFilter.split(',').map((t) => t.trim().toLowerCase()))
+      : null; // null means show all types
+
+    // Color functions (no-op if colors disabled)
+    const colorize = (text: string, colorCode: string) => (useColor ? `\x1b[${colorCode}m${text}\x1b[0m` : text);
+    const red = (text: string) => colorize(text, '31');
+    const yellow = (text: string) => colorize(text, '33');
+    const green = (text: string) => colorize(text, '32');
+    const cyan = (text: string) => colorize(text, '36');
+    const gray = (text: string) => colorize(text, '90');
+    const white = (text: string) => text;
+
+    const statusColor = (status: number) => {
+      if (status >= 400) return red;
+      if (status >= 300) return yellow;
+      if (status >= 200) return green;
+      return white;
+    };
+
+    const pad = (s: string, width: number) => (s.length >= width ? s : s + ' '.repeat(width - s.length));
+
+    // Helper function definitions (outside try/catch as they don't need error handling)
+    const formatTimestamp = () => {
+      const now = new Date();
+      return now.toTimeString().split(' ')[0] + '.' + now.getMilliseconds().toString().padStart(3, '0');
+    };
+
+    // Execution code (needs try/catch for error handling)
+    const { browser, page } = await getActivePage(port);
+
+    try {
+      // Same HTTPRequest instance reaches response/failure; WeakMap avoids URL collisions.
+      const requestStartedAt = new WeakMap<HTTPRequest, number>();
+
+      page.on('request', (req) => {
+        const resourceType = req.resourceType();
+        if (allowedTypes && !allowedTypes.has(resourceType)) {
+          return;
+        }
+        requestStartedAt.set(req, Date.now());
+        console.log(`${cyan('[REQ ]')} ${gray(formatTimestamp())} ${pad(req.method(), 6)} ${pad(resourceType, 9)} ${req.url()}`);
+      });
+
+      page.on('response', (resp) => {
+        const req = resp.request();
+        const resourceType = req.resourceType();
+        if (allowedTypes && !allowedTypes.has(resourceType)) {
+          return;
+        }
+        const status = resp.status();
+        const startedAt = requestStartedAt.get(req);
+        const ms = startedAt !== undefined ? Date.now() - startedAt : undefined;
+        const durationStr = ms !== undefined ? gray(` (${ms}ms)`) : '';
+        console.log(`${statusColor(status)('[RESP]')} ${gray(formatTimestamp())} ${pad(String(status), 6)} ${pad(resourceType, 9)} ${req.url()}${durationStr}`);
+      });
+
+      page.on('requestfailed', (req) => {
+        const resourceType = req.resourceType();
+        if (allowedTypes && !allowedTypes.has(resourceType)) {
+          return;
+        }
+        const failure = req.failure();
+        const reason = failure ? failure.errorText : 'unknown';
+        console.log(`${red('[FAIL]')} ${gray(formatTimestamp())} ${pad(req.method(), 6)} ${pad(resourceType, 9)} ${req.url()}  ${red('(' + reason + ')')}`);
+      });
+
+      if (follow) {
+        // Continuous monitoring mode
+        console.log(gray('Monitoring network requests (Ctrl+C to stop)...'));
+        const waitForExit = () =>
+          new Promise<void>((resolve) => {
+            const signals: NodeJS.Signals[] = ['SIGINT', 'SIGTERM', 'SIGHUP'];
+            const onSignal = () => {
+              cleanup();
+              resolve();
+            };
+            const onBeforeExit = () => {
+              cleanup();
+              resolve();
+            };
+            const cleanup = () => {
+              signals.forEach((signal) => process.off(signal, onSignal));
+              process.off('beforeExit', onBeforeExit);
+            };
+            signals.forEach((signal) => process.on(signal, onSignal));
+            process.on('beforeExit', onBeforeExit);
+          });
+
+        await waitForExit();
+      } else {
+        // One-shot mode with timeout
+        const duration = timeout ?? 5;
+        console.log(gray(`Capturing network requests for ${duration} seconds...`));
         await new Promise((resolve) => setTimeout(resolve, duration * 1000));
       }
     } finally {


### PR DESCRIPTION
## Summary

Agents driving the DevTools-attached Chrome from `browser-tools.ts` can now tail network traffic the same way they tail console output. `bun scripts/browser-tools.ts network --follow` prints `[REQ ]`, `[RESP]`, and `[FAIL]` lines as puppeteer reports them, with the same `--port`, `--types`, `--follow`, `--timeout`, `--color`, `--no-color` flag set as the existing `console` subcommand.

## Why this matters

`console` (PR #1) is the proven shape for tailing a CDP event stream from this script. Network traffic is the natural sibling event source: debugging XHR/fetch behavior currently means switching to another tool or running raw `eval` against the page. Mirroring `console` keeps the surface symmetric and the implementation under ~125 lines.

Resource-type filter accepts puppeteer's `resourceType()` enum: `document`, `stylesheet`, `image`, `media`, `font`, `script`, `xhr`, `fetch`, `manifest`, plus a few less common values. `websocket` is intentionally omitted from the help example because puppeteer's `request` and `response` events report only the WS upgrade handshake (frame traffic needs raw `Network.webSocketFrameSent` / `Received` via CDP). The help description carries a one-liner for users who try `--types websocket` anyway.

Output format:

- `[REQ ]` cyan, method (6-wide), resourceType (9-wide), URL
- `[RESP]` status-colored (green 2xx, yellow 3xx, red 4xx/5xx), status (6-wide), resourceType (9-wide), URL, gray `(Nms)` duration
- `[FAIL]` red, method, resourceType, URL, red error reason

Per-request timing uses `WeakMap<HTTPRequest, number>` keyed by the puppeteer request object, not URL+method, so parallel same-endpoint requests don't collide and the Map cleans up under `--follow`.

## Demo

![demo](https://files.catbox.moe/l6sqk2.gif)

Live capture from pre-PR smoke testing: `bun scripts/browser-tools.ts network --types document,script,image --timeout 3` against a navigation to `https://www.wikipedia.org/`. 13 real network events.

## Testing

No automated test suite for `browser-tools.ts` (consistent with the rest of the file). Manual smoke:

```bash
bun scripts/browser-tools.ts start --port 9222
bun scripts/browser-tools.ts nav https://example.com
bun scripts/browser-tools.ts network --types xhr,fetch --follow
bun scripts/browser-tools.ts network --timeout 3
bun scripts/browser-tools.ts kill --ports 9222 --force
```

CHANGELOG entry left for maintainer copy on merge per AGENTS.MD ("Contributor PR authors should not edit changelog; maintainer/AI adds entry at merge"). Suggested line:

```
## YYYY-MM-DD - Network Traffic Capture
- Added `network` command to `scripts/browser-tools.ts` for capturing and tailing Chrome DevTools network traffic with resource-type filtering, continuous follow mode, configurable timeouts, and concise method/status/URL/duration formatting.
```
