### PR TITLE
docs: group skills for skills.sh

### DIFF
--- a/skills.sh.json
+++ b/skills.sh.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://skills.sh/schemas/skills.sh.schema.json",
+  "notGrouped": "bottom",
+  "groupings": [
+    {
+      "title": "Agent Workflows",
+      "description": "Skills for agent instructions, transcript handling, skill hygiene, and reusable workflow design.",
+      "skills": [
+        "agent-transcript",
+        "create-cli",
+        "frontend-design",
+        "markdown-converter",
+        "oracle",
+        "skill-cleaner"
+      ]
+    },
+    {
+      "title": "GitHub & OpenClaw",
+      "description": "Skills for GitHub review, cache hygiene, project triage, and OpenClaw agent operations.",
+      "skills": [
+        "clawsweeper-status",
+        "codex-debugging",
+        "discord-clawd",
+        "github-author-context",
+        "github-cache-hygiene",
+        "github-deep-review",
+        "github-project-triage",
+        "openclaw-relay"
+      ]
+    },
+    {
+      "title": "Apple & Native Apps",
+      "description": "Skills for Swift, SwiftUI, Instruments, Hopper, app releases, and macOS VM labs.",
+      "skills": [
+        "hopper-debugger",
+        "instruments-profiling",
+        "native-app-performance",
+        "release-mac-app",
+        "swift-concurrency-expert",
+        "swiftui-liquid-glass",
+        "swiftui-performance-audit",
+        "swiftui-view-refactor",
+        "vm-lab"
+      ]
+    },
+    {
+      "title": "Browser, Media & AI",
+      "description": "Skills for browser automation, screenshots, image generation, video transcripts, and X API work.",
+      "skills": [
+        "browser-use",
+        "nano-banana-pro",
+        "openai-image-gen",
+        "peekaboo",
+        "video-transcript-downloader",
+        "xurl"
+      ]
+    },
+    {
+      "title": "Comms & Knowledge",
+      "description": "Skills for messaging, notes, reminders, music, speaking workflows, and personal archives.",
+      "skills": [
+        "beeper",
+        "notcrawl",
+        "obsidian",
+        "reminders",
+        "sonos",
+        "speaking",
+        "things-todo",
+        "twilio-sms",
+        "whatsapp"
+      ]
+    },
+    {
+      "title": "Infrastructure & Release",
+      "description": "Skills for domains, DNS, npm, Cloudflare, Wrangler, 1Password, SSH, releases, and remote machines.",
+      "skills": [
+        "clickclack",
+        "cloudflare-registrar",
+        "domain-dns-ops",
+        "mac-maintenance",
+        "npm",
+        "one-password",
+        "release-tweets",
+        "remote-mac",
+        "ssh-doctor",
+        "wrangler"
+      ]
+    }
+  ]
+}

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -25,6 +25,7 @@
         "github-cache-hygiene",
         "github-deep-review",
         "github-project-triage",
+        "maintainer-orchestrator",
         "openclaw-relay"
       ]
     },


### PR DESCRIPTION
Adds a root `skills.sh.json` so the skills.sh repository page can render this catalog in six curated sections instead of one install-sorted list. ClawHub's GitHub-backed publisher catalog uses the same manifest shape when a repository is configured as a source.

Scope:
- groups all 49 current remotely discoverable `skills/*/SKILL.md` slugs
- includes the newer `maintainer-orchestrator` skill under `GitHub & OpenClaw`
- keeps `notGrouped` at `bottom` so future unlisted skills remain visible
- does not change skill contents or CLI install behavior
- excludes nine tracked symlink entries because a fresh remote checkout does not contain their external target repositories and the `skills` CLI does not discover them

Consumer proof:
- `npx -y skills@1.5.11 add steipete/agent-scripts --list` cloned the public repository and found 49 skills, including `maintainer-orchestrator`.
- A synthetic merge tree (`origin/main` plus this manifest) passed the same CLI path with 49 skills.
- Current ClawHub consumer code at `e86aa30a77aa130bfdc10e65885d0623cc1db4f2` accepted the synthetic merge through `buildGitHubSkillSourceSnapshot` and `buildGitHubSkillCatalogDisplay`: manifest status `ok`, 49 discovered, section counts `6/9/9/6/9/10`, 49 rendered, zero `Other skills` entries.
- ClawHub parser: https://github.com/openclaw/clawhub/blob/e86aa30a77aa130bfdc10e65885d0623cc1db4f2/convex/lib/githubSkillSync.ts
- ClawHub catalog renderer: https://github.com/openclaw/clawhub/blob/e86aa30a77aa130bfdc10e65885d0623cc1db4f2/convex/lib/publisherCatalogDisplay.ts
- skills.sh behavior and schema: https://www.skills.sh/docs/customize and https://skills.sh/schemas/skills.sh.schema.json

Validation:
- `uvx check-jsonschema --schemafile https://skills.sh/schemas/skills.sh.schema.json skills.sh.json`
- inventory comparison: 49 current remote skills, 49 grouped, no missing, unknown, or duplicate entries
- `scripts/validate-skills`
- `hooks/pre-commit`
- repository CI smoke commands from `.github/workflows/ci.yml`
- `git diff --check origin/main...HEAD`
- autoreview, local and full branch: no accepted/actionable findings

Owner product choice:
- The six public group names and memberships are subjective repository taxonomy and still need Peter's endorsement.
- The live skills.sh page currently retains five historical slugs no longer present in the repository (`1password`, `brave-search`, `codex-review`, `parallels-vm`, `sonos-debug`). This manifest intentionally describes the canonical current 49-skill inventory; those historical records may remain under `Other skills`. Encoding stale telemetry aliases in repository metadata is not recommended.
