### PR TITLE
Restore codex-review helper with timeout guard

### DIFF
--- a/skills/codex-review/SKILL.md
+++ b/skills/codex-review/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: codex-review
+description: "Codex code review closeout: local dirty changes, PR branch vs main, parallel tests."
+---
+
+# Codex Review
+
+Run Codex's built-in code review as a closeout check. This is code review (`codex review`), not Guardian `auto_review` approval routing.
+
+Use when:
+- user asks for Codex review / autoreview / second-model review
+- after non-trivial code edits, before final/commit/ship
+- reviewing a local branch or PR branch after fixes
+
+## Contract
+
+- Treat review output as advisory. Never blindly apply it.
+- Verify every finding by reading the real code path and adjacent files.
+- Read dependency docs/source/types when the finding depends on external behavior.
+- Reject unrealistic edge cases, speculative risks, broad rewrites, and fixes that over-complicate the codebase.
+- Prefer small fixes at the right ownership boundary; no refactor unless it clearly improves the bug class.
+- Keep going until Codex review returns no accepted/actionable findings.
+- If a review-triggered fix changes code, rerun focused tests and rerun Codex review.
+- Never switch or override the review model. If the review hits model capacity, retry the same command a few times with the same model. If it hits sandbox/permission limits, use the helper's `--full-access` option instead of changing models.
+- Stop as soon as the review command/helper exits 0 with no accepted/actionable findings. Do not run an extra direct `codex review` just to get a nicer "clean" line, a second opinion, or clearer closeout wording.
+- Treat the helper's successful exit plus absence of actionable findings as the clean review result, even if the underlying Codex CLI output is terse.
+- If rejecting a finding as intentional/not worth fixing, add a brief inline code comment only when it explains a real invariant or ownership decision that future reviewers should know.
+- Do not push just to review. Push only when the user requested push/ship/PR update.
+
+## Pick Target
+
+Dirty local work:
+
+```bash
+codex review --uncommitted
+```
+
+Use this only when the patch is actually unstaged/staged/untracked in the
+current checkout. For committed, pushed, or PR work, review the branch against
+its base instead; do not force `--mode local` / `--uncommitted` just because the
+helper docs mention dirty work first. A clean `--uncommitted` review only proves
+there is no local patch.
+
+Branch/PR work:
+
+```bash
+git fetch origin
+codex review --base origin/main
+```
+
+Do not pass an inline prompt with `--base`; current CLI rejects `--base` + `[PROMPT]` even though help text is ambiguous. If custom instructions are needed, run the plain base review first, then do a local/manual follow-up pass.
+
+If an open PR exists, use its actual base:
+
+```bash
+base=$(gh pr view --json baseRefName --jq .baseRefName)
+codex review --base "origin/$base"
+```
+
+Committed single change:
+
+```bash
+codex review --commit HEAD
+```
+
+## Parallel Closeout
+
+Format first if formatting can change line locations. Then it is OK to run tests and review in parallel:
+
+```bash
+scripts/codex-review --parallel-tests "<focused test command>"
+```
+
+Tradeoff: tests may force code changes that stale the review. If tests or review lead to code edits, rerun the affected tests and rerun review until no accepted/actionable findings remain. Once that rerun exits cleanly, stop; do not spend another long review cycle on redundant confirmation.
+
+## Context Efficiency
+
+Codex review is usually noisy. Default to a subagent filter when subagents are available. Ask it to run the review and return only:
+- actionable findings it accepts
+- findings it rejects, with one-line reason
+- exact files/tests to rerun
+
+Run inline only for tiny changes or when subagents are unavailable.
+
+## Helper
+
+Bundled helper:
+
+```bash
+~/.codex/skills/codex-review/scripts/codex-review --help
+```
+
+If installed from `agent-scripts`, path is:
+
+```bash
+/Users/antoniocalistopato/Projects/agent-scripts/skills/codex-review/scripts/codex-review --help
+```
+
+The helper:
+- chooses dirty `--uncommitted` first
+- otherwise uses current PR base if `gh pr view` works
+- otherwise uses the PR/base branch when the current branch has committed changes, including `main` ahead of `origin/main`
+- should be left in `--mode auto` or forced to `--mode branch` for committed/PR work; do not force `--mode local` after committing
+- writes only to stdout unless `--output` or `CODEX_REVIEW_OUTPUT` is set
+- supports `--dry-run` and `--parallel-tests`
+- supports `--review-timeout SECONDS` / `CODEX_REVIEW_TIMEOUT_SECONDS` so a wedged nested review exits cleanly instead of blocking the closeout indefinitely; default is 1800 seconds, and `0` disables the timeout
+- supports `--full-access` for nested review runs that need localhost bind/listen tests
+- blocks recursive nested `codex review` invocations with exit `125` so a review session cannot call another review session and loop
+- prints `codex-review clean: no accepted/actionable findings reported` when the selected review command exits 0
+
+## Final Report
+
+Include:
+- review command used
+- tests/proof run
+- findings accepted/rejected, briefly why
+- the clean review result from the final helper/review run, or why a remaining finding was consciously rejected
+
+Do not run another Codex review solely to improve the final report wording. If the final helper run exited 0 and produced no accepted/actionable findings, report that exact run as clean.

--- a/skills/codex-review/scripts/codex-review
+++ b/skills/codex-review/scripts/codex-review
@@ -1,0 +1,401 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: codex-review [options]
+
+Options:
+  --mode auto|local|branch   Target selection. Default: auto.
+  --base REF                 Base ref for branch review. Default: PR base or origin/main.
+  --codex-bin PATH           Codex binary. Default: codex.
+  --full-access              Run nested Codex review without sandbox/approval prompts.
+  --output FILE              Also save output to file.
+  --parallel-tests CMD       Run review and test command concurrently.
+  --review-timeout SECONDS   Kill nested review after this many seconds. Default: 1800; 0 disables.
+  --dry-run                  Print selected commands, do not run.
+  -h, --help                 Show help.
+
+Modes:
+  local   codex review --uncommitted
+  branch  codex review --base <base>
+  auto    dirty tree -> local, else PR/current branch -> branch
+EOF
+}
+
+mode=auto
+base_ref=
+codex_bin=${CODEX_BIN:-codex}
+codex_args=()
+output=${CODEX_REVIEW_OUTPUT:-}
+parallel_tests=
+review_timeout_seconds=${CODEX_REVIEW_TIMEOUT_SECONDS:-1800}
+dry_run=false
+
+if [[ "${CODEX_REVIEW_HELPER_ACTIVE:-}" == "1" ]]; then
+  echo "codex-review recursion guard: refusing to start a nested codex-review helper run" >&2
+  exit 125
+fi
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)
+      mode=${2:-}
+      shift 2
+      ;;
+    --base)
+      base_ref=${2:-}
+      shift 2
+      ;;
+    --codex-bin)
+      codex_bin=${2:-}
+      shift 2
+      ;;
+    --full-access)
+      codex_args+=(--dangerously-bypass-approvals-and-sandbox)
+      shift
+      ;;
+    --output)
+      output=${2:-}
+      shift 2
+      ;;
+    --parallel-tests)
+      parallel_tests=${2:-}
+      shift 2
+      ;;
+    --review-timeout)
+      review_timeout_seconds=${2:-}
+      shift 2
+      ;;
+    --dry-run)
+      dry_run=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$mode" in
+  auto|local|branch) ;;
+  *)
+    echo "invalid --mode: $mode" >&2
+    exit 2
+    ;;
+esac
+
+case "$review_timeout_seconds" in
+  ''|*[!0-9]*)
+    echo "invalid --review-timeout: $review_timeout_seconds" >&2
+    exit 2
+    ;;
+esac
+
+git rev-parse --show-toplevel >/dev/null
+
+if [[ "$codex_bin" == */* ]]; then
+  codex_real_bin="$codex_bin"
+else
+  codex_real_bin=$(command -v "$codex_bin")
+fi
+
+current_branch=$(git branch --show-current 2>/dev/null || true)
+dirty=false
+if [[ -n "$(git status --porcelain)" ]]; then
+  dirty=true
+fi
+
+pr_url=
+if [[ -z "$base_ref" && "$mode" != local ]] && command -v gh >/dev/null 2>&1; then
+  if pr_lines=$(gh pr view --json baseRefName,url --jq '[.baseRefName, .url] | @tsv' 2>/dev/null); then
+    base_name=${pr_lines%%$'\t'*}
+    pr_url=${pr_lines#*$'\t'}
+    if [[ -n "$base_name" ]]; then
+      base_ref="origin/$base_name"
+    fi
+  fi
+fi
+
+if [[ -z "$base_ref" ]]; then
+  base_ref=origin/main
+fi
+
+branch_has_delta=false
+if [[ -n "$current_branch" ]] && git rev-parse --verify --quiet "$base_ref^{commit}" >/dev/null; then
+  if [[ -n "$(git rev-list --max-count=1 "$base_ref..HEAD" 2>/dev/null)" ]]; then
+    branch_has_delta=true
+  fi
+fi
+
+review_kind=
+if [[ "$mode" == local || ( "$mode" == auto && "$dirty" == true ) ]]; then
+  review_kind=local
+elif [[ "$mode" == branch || ( "$mode" == auto && -n "$current_branch" && ( "$current_branch" != "main" || "$branch_has_delta" == true ) ) ]]; then
+  review_kind=branch
+else
+  echo "no review target: clean main checkout and no forced mode" >&2
+  exit 1
+fi
+
+review_cmd=("$codex_real_bin")
+if (( ${#codex_args[@]} > 0 )); then
+  review_cmd+=("${codex_args[@]}")
+fi
+if [[ "$review_kind" == local ]]; then
+  review_cmd+=(review --uncommitted)
+else
+  review_cmd+=(review --base "$base_ref")
+fi
+
+printf 'codex-review target: %s\n' "$review_kind"
+printf 'branch: %s\n' "${current_branch:-detached}"
+if [[ -n "$pr_url" ]]; then
+  printf 'pr: %s\n' "$pr_url"
+fi
+printf 'review:'
+printf ' %q' "${review_cmd[@]}"
+printf '\n'
+if [[ -n "$parallel_tests" ]]; then
+  printf 'tests: %s\n' "$parallel_tests"
+fi
+if [[ "$review_timeout_seconds" != 0 ]]; then
+  printf 'review-timeout: %ss\n' "$review_timeout_seconds"
+else
+  printf 'review-timeout: disabled\n'
+fi
+if [[ "$review_kind" == branch ]]; then
+  printf 'fetch: git fetch origin --quiet\n'
+fi
+if [[ -n "$output" ]]; then
+  printf 'output: %s\n' "$output"
+fi
+
+if [[ "$dry_run" == true ]]; then
+  exit 0
+fi
+
+if [[ "$review_kind" == branch ]]; then
+  git fetch origin --quiet || {
+    echo "warning: git fetch origin failed; reviewing with existing refs" >&2
+  }
+fi
+
+review_output=$output
+review_output_is_temp=false
+guard_dir=
+if [[ -z "$review_output" ]]; then
+  review_output=$(mktemp)
+  review_output_is_temp=true
+fi
+
+guard_dir=$(mktemp -d)
+cat > "$guard_dir/codex" <<EOF
+#!/usr/bin/env bash
+if [[ "\${CODEX_REVIEW_HELPER_ACTIVE:-}" == "1" && "\${1:-}" == "review" ]]; then
+  echo "codex-review recursion guard: refusing nested codex review invocation" >&2
+  exit 125
+fi
+exec "$codex_real_bin" "\$@"
+EOF
+chmod +x "$guard_dir/codex"
+
+cleanup() {
+  if [[ "${review_output_is_temp:-false}" == true && -n "${review_output:-}" ]]; then
+    rm -f "$review_output"
+  fi
+  if [[ -n "${guard_dir:-}" ]]; then
+    rm -rf "$guard_dir"
+  fi
+}
+trap cleanup EXIT
+
+run_review() {
+  mkdir -p "$(dirname "$review_output")"
+  if [[ "$review_timeout_seconds" == 0 ]]; then
+    CODEX_REVIEW_HELPER_ACTIVE=1 PATH="$guard_dir:$PATH" "${review_cmd[@]}" 2>&1 | tee "$review_output"
+    return $?
+  fi
+
+  CODEX_REVIEW_HELPER_ACTIVE=1 PATH="$guard_dir:$PATH" \
+    python3 - "$review_timeout_seconds" "$review_output" "${review_cmd[@]}" <<'PY'
+import fcntl
+import os
+import signal
+import subprocess
+import sys
+import time
+
+timeout = int(sys.argv[1])
+output_path = sys.argv[2]
+cmd = sys.argv[3:]
+
+preexec = os.setsid if hasattr(os, "setsid") else None
+proc = subprocess.Popen(
+    cmd,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT,
+    env=os.environ.copy(),
+    preexec_fn=preexec,
+)
+
+assert proc.stdout is not None
+fd = proc.stdout.fileno()
+flags = fcntl.fcntl(fd, fcntl.F_GETFL)
+fcntl.fcntl(fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+
+started_at = time.monotonic()
+stdout_fd = sys.stdout.buffer.fileno()
+
+def emit(chunk: bytes, out) -> None:
+    if not chunk:
+        return
+    os.write(stdout_fd, chunk)
+    out.write(chunk)
+    out.flush()
+
+def drain(out) -> None:
+    while True:
+        try:
+            chunk = os.read(fd, 65536)
+        except BlockingIOError:
+            return
+        if not chunk:
+            return
+        emit(chunk, out)
+
+with open(output_path, "wb") as out:
+    while True:
+        drain(out)
+        status = proc.poll()
+        if status is not None:
+            drain(out)
+            sys.exit(status)
+
+        if time.monotonic() - started_at >= timeout:
+            msg = f"codex-review timeout: nested review exceeded {timeout}s; terminating\n".encode()
+            emit(msg, out)
+            try:
+                if hasattr(os, "killpg"):
+                    os.killpg(proc.pid, signal.SIGTERM)
+                else:
+                    proc.terminate()
+            except ProcessLookupError:
+                pass
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                try:
+                    if hasattr(os, "killpg"):
+                        os.killpg(proc.pid, signal.SIGKILL)
+                    else:
+                        proc.kill()
+                except ProcessLookupError:
+                    pass
+                proc.wait()
+            drain(out)
+            sys.exit(124)
+
+        time.sleep(0.1)
+PY
+}
+
+elapsed_since() {
+  local started_at=$1
+  local finished_at
+  finished_at=$(date +%s)
+  printf '%s\n' "$((finished_at - started_at))"
+}
+
+format_elapsed() {
+  local seconds=$1
+  if (( seconds < 60 )); then
+    printf '%ss\n' "$seconds"
+  else
+    printf '%sm%ss\n' "$((seconds / 60))" "$((seconds % 60))"
+  fi
+}
+
+review_output_empty() {
+  [[ ! -s "$review_output" ]] || ! grep -q '[^[:space:]]' "$review_output"
+}
+
+review_output_has_findings() {
+  grep -Eq '\[P[0-3]\]' "$review_output"
+}
+
+report_clean_review_or_fail() {
+  local elapsed_text
+  elapsed_text=$(format_elapsed "${review_elapsed_seconds:-0}")
+
+  if review_output_has_findings; then
+    printf 'codex-review complete after %s\n' "$elapsed_text"
+    printf 'codex-review findings: accepted/actionable findings reported\n'
+    return 1
+  fi
+  if review_output_empty; then
+    printf 'codex-review complete after %s; no output\n' "$elapsed_text"
+    return 1
+  fi
+  printf 'codex-review complete after %s\n' "$elapsed_text"
+  printf 'codex-review clean: no accepted/actionable findings reported\n'
+}
+
+if [[ -z "$parallel_tests" ]]; then
+  review_started_at=$(date +%s)
+  set +e
+  run_review
+  review_status=$?
+  review_elapsed_seconds=$(elapsed_since "$review_started_at")
+  set -e
+  if [[ "$review_status" == 0 ]]; then
+    report_clean_review_or_fail
+    exit $?
+  fi
+  exit "$review_status"
+fi
+
+review_status_file=$(mktemp)
+review_elapsed_file=$(mktemp)
+tests_status_file=$(mktemp)
+
+(
+  set +e
+  review_started_at=$(date +%s)
+  run_review
+  status=$?
+  elapsed=$(elapsed_since "$review_started_at")
+  printf '%s\n' "$status" > "$review_status_file"
+  printf '%s\n' "$elapsed" > "$review_elapsed_file"
+) &
+review_pid=$!
+
+(
+  set +e
+  bash -lc "$parallel_tests"
+  status=$?
+  printf '%s\n' "$status" > "$tests_status_file"
+) &
+tests_pid=$!
+
+wait "$review_pid" || true
+wait "$tests_pid" || true
+
+review_status=$(cat "$review_status_file")
+review_elapsed_seconds=$(cat "$review_elapsed_file")
+tests_status=$(cat "$tests_status_file")
+rm -f "$review_status_file" "$review_elapsed_file" "$tests_status_file"
+
+printf 'codex-review exit: %s\n' "$review_status"
+printf 'tests exit: %s\n' "$tests_status"
+
+if [[ "$review_status" != 0 || "$tests_status" != 0 ]]; then
+  exit 1
+fi
+
+report_clean_review_or_fail


### PR DESCRIPTION
Restores the codex-review helper skill and adds a timeout guard so nested codex review runs terminate cleanly instead of wedging indefinitely.\n\nLocal verification:\n- bash -n skills/codex-review/scripts/codex-review\n- skills/codex-review/scripts/codex-review --mode local --review-timeout 1 --dry-run