### PR TITLE
[codex] update GitHub Actions pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
   smoke:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## What

Update the CI workflow action pins:

- `actions/checkout` from v4 to v6
- `actions/setup-node` from v4 to v6

## Why

Keeps the repo's GitHub Actions dependencies current while preserving the existing Node 22 and npm-cache configuration. `setup-node` v6's noted breaking change is around automatic caching; this workflow already configures npm caching explicitly.

## Validation

- `scripts/validate-skills`
- `skills/clawsweeper-status/scripts/clawsweeper-status.test.sh`
- `npm ci` in `skills/video-transcript-downloader`
- `node -e "import('youtube-transcript-plus').then(m => { if (typeof m.YoutubeTranscript?.fetchTranscript !== 'function') process.exit(1); })"`
- `./scripts/vtd.js transcript --help` in `skills/video-transcript-downloader`
- `git diff --check`
