### PR TITLE
ci: update checkout to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   smoke:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary

- update `actions/checkout` from v6 to stable v7
- retain the existing GitHub-hosted `ubuntu-latest` workflow and Node 22 test configuration

Upstream: https://github.com/actions/checkout/releases/tag/v7.0.0

## Proof

- workflow YAML parse and `actionlint`
- `scripts/validate-skills`
- `skills/clawsweeper-status/scripts/clawsweeper-status.test.sh`
- `git diff --check`
- autoreview: clean, no accepted/actionable findings
- Public Model Identifier Gate: PASS; no model identifiers added

The PR's own CI run is the live workflow proof for the v7 action.
