### PR TITLE
chore: refresh browser extraction libraries

### DIFF
--- a/scripts/browser-tools.ts
+++ b/scripts/browser-tools.ts
@@ -951,8 +951,8 @@ async function ensureReadability(page: any) {
     // ignore
   }
   const scripts = [
-    'https://unpkg.com/@mozilla/readability@0.4.4/Readability.js',
-    'https://unpkg.com/turndown@7.1.2/dist/turndown.js',
+    'https://unpkg.com/@mozilla/readability@0.6.0/Readability.js',
+    'https://unpkg.com/turndown@7.2.4/dist/turndown.js',
     'https://unpkg.com/turndown-plugin-gfm@1.0.2/dist/turndown-plugin-gfm.js',
   ];
   for (const src of scripts) {


### PR DESCRIPTION
## Summary

- update the browser content extractor from `@mozilla/readability` 0.4.4 to 0.6.0
- update Turndown from 7.1.2 to 7.2.4
- retain the existing GFM plugin and extraction behavior

## Proof

- both pinned unpkg assets return HTTP 200
- existing-profile Chrome test loaded all three scripts, parsed Example Domain with Readability, and converted its article to Markdown with Turndown + GFM
- `bun scripts/browser-tools.ts --help` — success
- `scripts/validate-skills` — 49 skills validated
- autoreview (`--mode local`) — clean, no accepted/actionable findings

## Existing gap

- the documented optional `bun build ... --compile` command still needs `commander` and `puppeteer-core` installed; this repo has no root dependency manifest today, independent of these two CDN pins
