### PR TITLE
fix: read skill files as UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ summary: Timeline of guardrail helper changes mirrored from Sweetistics and rela
 
 # Changelog
 
+## 2026-07-02 — UTF-8 Skill Validation
+- Made skill validation explicitly read UTF-8 so C locales accept non-ASCII skill front matter. Thanks @chaochaoweb3.
+
 ## 2026-07-02 — Orchestrator Ownership
 - Kept `maintainer-orchestrator` skill maintenance in the root orchestration session and enforced exactly one Codex app thread per project, removing project-to-task thread fan-out including the OpenClaw exception.
 

--- a/scripts/validate-skills
+++ b/scripts/validate-skills
@@ -37,7 +37,7 @@ errors = []
 names = {}
 
 skill_files.each do |path|
-  text = File.read(path)
+  text = File.read(path, encoding: "UTF-8")
   data, error = load_front_matter(path, text)
 
   if error


### PR DESCRIPTION
## Summary
- read `SKILL.md` files with explicit UTF-8 encoding in `scripts/validate-skills`
- prevents Ruby from falling back to US-ASCII under C/invalid locale settings and rejecting non-ASCII skill front matter

## Validation
- `scripts/validate-skills`
- `env LC_ALL=C LANG=C scripts/validate-skills`
- `git diff --check`

Proof for the C-locale path after this patch:

```text
$ PATH=/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin env LC_ALL=C LANG=C scripts/validate-skills
Validated 49 skill(s).
```

Note: full CI browser-helper build was not run locally because `bun` is not installed in this environment.
