### PR TITLE
fix(xurl): use install kind "node" instead of invalid "npm"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ summary: Timeline of guardrail helper changes mirrored from Sweetistics and rela
 
 # Changelog
 
+## 2026-07-11 — xurl Install Discovery
+- Fixed the xurl skill's npm installer metadata so OpenClaw discovers the supported Node installation path. Thanks @not-stbenjam.
+
 ## 2026-07-09 — ClawSweeper Worker Capacity
 - Made `clawsweeper-status` report actual Codex job utilization against configured capacity, exact-review queue and target occupancy, and workflow concurrency waiters separately from queued jobs.
 

--- a/skills/xurl/SKILL.md
+++ b/skills/xurl/SKILL.md
@@ -18,7 +18,7 @@ metadata:
             },
             {
               "id": "npm",
-              "kind": "npm",
+              "kind": "node",
               "package": "@xdevplatform/xurl",
               "bins": ["xurl"],
               "label": "Install xurl (npm)",


### PR DESCRIPTION
Trivial fix that skillsaw caught. It triggered the
[openclaw-metadata](https://skillsaw.org/rules/openclaw-metadata/) rule:

> ⚠ WARNING (openclaw-metadata) [skills/xurl/SKILL.md:21]:
> 'metadata.openclaw.install[1].kind' is 'npm', expected one of:
> ['brew', 'download', 'go', 'node', 'uv']

`npm` isn't a valid install `kind` — it's a value of the
`skills.install.nodeManager` setting (`npm`/`pnpm`/`yarn`/`bun`), which the
`node` kind honors. npm-based installs use `kind: "node"` with a `package`
field, so this changes only `kind` (`id`/`package`/`bins` are left as-is).

```diff
             {
               "id": "npm",
-              "kind": "npm",
+              "kind": "node",
               "package": "@xdevplatform/xurl",
               "bins": ["xurl"],
               "label": "Install xurl (npm)",
             },
```

## Real-behavior proof (openclaw 2026.6.11, throwaway container)

Ran openclaw's own `skills info` against the bundled xurl skill, toggling
only the second installer's `kind`. Notably the published package already
ships `kind: "npm"`, so this reproduces against the shipped metadata.

**Before — `kind: "npm"` (as shipped):** openclaw drops the installer as an
unsupported kind. The npm option never appears — only brew is offered, so
xurl is uninstallable via openclaw on any machine without Homebrew:

```
$ openclaw skills info xurl
Install options:
  → Install xurl (brew)
```
```json
"install": [
  { "id": "brew", "kind": "brew", "label": "Install xurl (brew)", "bins": ["xurl"] }
]
```

**After — `kind: "node"` (this PR):** openclaw resolves the installer and
surfaces the npm option:

```
$ openclaw skills info xurl
Install options:
  → Install @xdevplatform/xurl (npm)
```
```json
"install": [
  { "id": "npm", "kind": "node", "label": "Install @xdevplatform/xurl (npm)", "bins": ["xurl"] }
]
```

The `id: "npm"` selector is preserved (kept from the original), so this
isn't a compatibility change — only the invalid `kind` is corrected.

Refs: https://docs.openclaw.ai/tools/skills
