### PR TITLE
docs(codex-first): cover ChatGPT-app-bundled Codex on PATH

### DIFF
--- a/skills/codex-first/SKILL.md
+++ b/skills/codex-first/SKILL.md
@@ -48,9 +48,14 @@ command codex exec --yolo -C <repo> \
 
 - Model default: `gpt-5.6-sol`, effort `high`, fast mode on — pin all three explicitly; don't rely on user config.
 - `--yolo` is the house default; Codex may run commands/tests freely. Keep prompts scoped to the target repo.
-- `command codex` bypasses any interactive shell alias. Codex must resolve to a **real binary path, not a symlink** (see below). Two install shapes:
-  - node/standalone install: usually already on PATH; if not, `fnm exec --using default -- codex`.
-  - ChatGPT desktop app (Codex merged into it, July 2026): the binary ships at `/Applications/ChatGPT.app/Contents/Resources/codex` and shares the app's ChatGPT sign-in. Put it on PATH with an **exec-wrapper, never a symlink** — codex locates sibling helpers (e.g. `codex-code-mode-host`) relative to its invocation path, so a symlink misresolves them and `exec` dies with `the workspace execution host is missing` (agent runs, but every file edit fails). Wrapper: `printf '#!/bin/sh\nexec "/Applications/ChatGPT.app/Contents/Resources/codex" "$@"\n' > ~/.local/bin/codex && chmod +x ~/.local/bin/codex`. Or install the self-contained CLI via `curl -fsSL https://chatgpt.com/codex/install.sh | sh`, which has no wrapper caveat.
+- `command codex` bypasses any interactive shell alias. If codex isn't on PATH, it depends on how it was installed:
+  - node/standalone install: `fnm exec --using default -- codex` (a package-manager symlink or shim on PATH is fine — this caveat is only about the app bundle below).
+  - ChatGPT desktop app (Codex merged into it, July 2026): the CLI ships bundled at `/Applications/ChatGPT.app/Contents/Resources/codex` and shares the app's ChatGPT sign-in. Expose **that** binary with an **exec-wrapper, not a symlink** — it locates sibling helpers (e.g. `codex-code-mode-host`) relative to its own invocation path, so a symlink to it misresolves them and `exec` dies with `the workspace execution host is missing` (the agent runs, but every file edit fails). Non-destructive wrapper (won't clobber an existing launcher):
+    ```sh
+    mkdir -p ~/.local/bin
+    [ -e ~/.local/bin/codex ] || { printf '#!/bin/sh\nexec "/Applications/ChatGPT.app/Contents/Resources/codex" "$@"\n' > ~/.local/bin/codex && chmod +x ~/.local/bin/codex; }
+    ```
+    Or install the self-contained CLI via `curl -fsSL https://chatgpt.com/codex/install.sh | sh`, which needs no wrapper.
 - stderr suppressed (thinking noise bloats context); drop `2>/dev/null` only to debug a failing run
 - read `-o` file for the result; don't parse the JSONL stream
 - long runs: Bash run_in_background, read `-o` file on exit; don't kill quiet runs <30 min

--- a/skills/codex-first/SKILL.md
+++ b/skills/codex-first/SKILL.md
@@ -48,7 +48,9 @@ command codex exec --yolo -C <repo> \
 
 - Model default: `gpt-5.6-sol`, effort `high`, fast mode on — pin all three explicitly; don't rely on user config.
 - `--yolo` is the house default; Codex may run commands/tests freely. Keep prompts scoped to the target repo.
-- `command codex` bypasses the interactive zsh wrapper; if not on PATH: `fnm exec --using default -- codex`
+- `command codex` bypasses any interactive shell alias. Codex must resolve to a **real binary path, not a symlink** (see below). Two install shapes:
+  - node/standalone install: usually already on PATH; if not, `fnm exec --using default -- codex`.
+  - ChatGPT desktop app (Codex merged into it, July 2026): the binary ships at `/Applications/ChatGPT.app/Contents/Resources/codex` and shares the app's ChatGPT sign-in. Put it on PATH with an **exec-wrapper, never a symlink** — codex locates sibling helpers (e.g. `codex-code-mode-host`) relative to its invocation path, so a symlink misresolves them and `exec` dies with `the workspace execution host is missing` (agent runs, but every file edit fails). Wrapper: `printf '#!/bin/sh\nexec "/Applications/ChatGPT.app/Contents/Resources/codex" "$@"\n' > ~/.local/bin/codex && chmod +x ~/.local/bin/codex`. Or install the self-contained CLI via `curl -fsSL https://chatgpt.com/codex/install.sh | sh`, which has no wrapper caveat.
 - stderr suppressed (thinking noise bloats context); drop `2>/dev/null` only to debug a failing run
 - read `-o` file for the result; don't parse the JSONL stream
 - long runs: Bash run_in_background, read `-o` file on exit; don't kill quiet runs <30 min

--- a/skills/codex-first/SKILL.md
+++ b/skills/codex-first/SKILL.md
@@ -49,8 +49,8 @@ command codex exec --yolo -C <repo> \
 - Model default: `gpt-5.6-sol`, effort `high`, fast mode on — pin all three explicitly; don't rely on user config.
 - `--yolo` is the house default; Codex may run commands/tests freely. Keep prompts scoped to the target repo.
 - `command codex` bypasses any interactive shell alias. If codex isn't on PATH, it depends on how it was installed:
-  - node/standalone install: `fnm exec --using default -- codex` (a package-manager symlink or shim on PATH is fine — this caveat is only about the app bundle below).
-  - ChatGPT desktop app (Codex merged into it, July 2026): the CLI ships bundled at `/Applications/ChatGPT.app/Contents/Resources/codex` and shares the app's ChatGPT sign-in. Expose **that** binary with an **exec-wrapper, not a symlink** — it locates sibling helpers (e.g. `codex-code-mode-host`) relative to its own invocation path, so a symlink to it misresolves them and `exec` dies with `the workspace execution host is missing` (the agent runs, but every file edit fails). Non-destructive wrapper (won't clobber an existing launcher):
+  - node/standalone install: `fnm exec --using default -- codex`
+  - ChatGPT desktop app: the CLI ships bundled at `/Applications/ChatGPT.app/Contents/Resources/codex` and shares the app's ChatGPT sign-in. Expose **that** binary with an **exec-wrapper, not a symlink**
     ```sh
     mkdir -p ~/.local/bin
     [ -e ~/.local/bin/codex ] || { printf '#!/bin/sh\nexec "/Applications/ChatGPT.app/Contents/Resources/codex" "$@"\n' > ~/.local/bin/codex && chmod +x ~/.local/bin/codex; }

--- a/skills/codex-first/SKILL.md
+++ b/skills/codex-first/SKILL.md
@@ -57,7 +57,7 @@ command codex exec --yolo -C <repo> \
 - `--yolo` is the house default; Codex may run commands/tests freely. Keep prompts scoped to the target repo.
 - `command codex` bypasses any interactive shell alias. If codex isn't on PATH, it depends on how it was installed:
   - node/standalone install: `fnm exec --using default -- codex`
-  - ChatGPT desktop app: the CLI ships bundled at `/Applications/ChatGPT.app/Contents/Resources/codex` and shares the app's ChatGPT sign-in. Expose **that** binary with an **exec-wrapper, not a symlink**. Ensure `~/.local/bin` stays on PATH (for zsh, persist the export in `~/.zshrc`), then:
+  - ChatGPT desktop app: the CLI ships bundled at `/Applications/ChatGPT.app/Contents/Resources/codex`. Expose **that** binary with an **exec-wrapper, not a symlink**. Ensure `~/.local/bin` stays on PATH (for zsh, persist the export in `~/.zshrc`), then:
     ```sh
     mkdir -p "$HOME/.local/bin"
     export PATH="$HOME/.local/bin:$PATH"


### PR DESCRIPTION
Codex merged into the ChatGPT desktop app (July 2026), so the CLI now also ships as a bundled binary at `/Applications/ChatGPT.app/Contents/Resources/codex`.

Document both install shapes and the symlink trap: the bundled binary resolves sibling helpers (e.g. `codex-code-mode-host`) relative to its invocation path, so symlinking it onto PATH makes `exec` fail with "the workspace execution host is missing". Use an exec-wrapper or the standalone installer instead.

## Review updates (addresses ClawSweeper findings)

- **Scoped the no-symlink rule to the app-bundled binary** (P2). Package-manager symlinks/shims from npm/standalone installs are fine and no longer discouraged — the caveat now applies only to the ChatGPT.app binary, which is the case that actually breaks.
- **Made the wrapper recipe non-destructive** (P2). It now `mkdir -p ~/.local/bin` first and skips if a launcher already exists, so it works on a fresh app-only machine and never clobbers an existing `codex`.

## Behavior proof (codex-cli 0.144.0-alpha.4, macOS)

Isolated repro — identical prompt and flags (`exec --yolo --skip-git-repo-check -m gpt-5.6-sol -c model_reasoning_effort=low --disable fast_mode`), only the launcher varies:

| Launcher | Result |
|---|---|
| symlink → bundled binary | ❌ `Unable to create ok.txt: the workspace execution host is missing` (agent runs, file edit fails) |
| exec-wrapper → bundled binary | ✅ `ok.txt` created, contents `hi` |
| bundled binary directly (control) | ✅ `ok.txt` created, contents `hi` |

```text
# codex version
codex-cli 0.144.0-alpha.4

## SYMLINK on PATH
Unable to create `ok.txt`: the workspace execution host is missing, so no files were changed.
[exit=0] ok.txt=[]

## EXEC-WRAPPER
Changed: `ok.txt` — contains exactly `hi`.
[exit=0] ok.txt=[hi]

## DIRECT (control)
Created `ok.txt` containing exactly `hi`.
[exit=0] ok.txt=[hi]
```

Same binary in all three runs; the only difference is whether it was reached through a symlink. That isolates the failure to symlink invocation of the app-bundled binary (helper resolution relative to `argv[0]`), not symlinks in general — which is why the fix scopes the warning to the app bundle.
