### PR TITLE
chore: repair CI and refresh dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
           cache-dependency-path: skills/video-transcript-downloader/package-lock.json
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,24 +6,24 @@
       "name": "agent-scripts-tools",
       "dependencies": {
         "commander": "^15.0.0",
-        "puppeteer-core": "^25.3.0",
+        "puppeteer-core": "^25.5.0",
       },
     },
   },
   "packages": {
-    "@puppeteer/browsers": ["@puppeteer/browsers@3.0.6", "", { "dependencies": { "modern-tar": "^0.7.6", "yargs": "^18.0.0" }, "peerDependencies": { "proxy-agent": ">=8.0.1", "yauzl": "^2.10.0 || ^3.4.0" }, "optionalPeers": ["proxy-agent", "yauzl"], "bin": { "browsers": "lib/main-cli.js" } }, "sha512-B/gKoqlFkzhvzsI6jo9K1cZz9o5ypviVv/xu8CwA4grZzyVwN+XfkT+tu8T1zrauuEXv6VhS2oGX+6NL95WcKA=="],
+    "@puppeteer/browsers": ["@puppeteer/browsers@3.1.0", "", { "dependencies": { "modern-tar": "^0.7.6", "yargs": "^18.0.0" }, "peerDependencies": { "proxy-agent": ">=8.0.1", "yauzl": "^2.10.0 || ^3.4.0" }, "optionalPeers": ["proxy-agent", "yauzl"], "bin": { "browsers": "lib/main-cli.js" } }, "sha512-RDLpio3fH/qrj5k4DVY6eyiN8tCS0Zovd/6jW//n605oeqkWcUjn+3k+9ZtZBnbwMpsu0F7xDIiKXvVmG5c5Bw=="],
 
     "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
-    "chromium-bidi": ["chromium-bidi@16.0.1", "", { "dependencies": { "mitt": "^3.0.1", "zod": "^3.24.1" }, "peerDependencies": { "devtools-protocol": "*" } }, "sha512-J63PGu/9PpeCwLIcKYyzWP6yaVL5pxuBc0shlYCYM8BaAkmlwiQboXO1iNbOgSDbVklEyYFfNEcHD8oOAWacUA=="],
+    "chromium-bidi": ["chromium-bidi@17.0.2", "", { "dependencies": { "mitt": "^3.0.1", "zod": "^3.24.1" }, "peerDependencies": { "devtools-protocol": "*" } }, "sha512-5v9GQFhTktFvotn/OFNJBmKLKRAb6n9r0bVCwf7sHgWc3/JryK0bj1nn93L3pHFrfgcsu6Be6EWsDi+1XHTGDg=="],
 
     "cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
 
     "commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
 
-    "devtools-protocol": ["devtools-protocol@0.0.1638949", "", {}, "sha512-mXwg4Fqnv0WR4iuAT/gYUmctNkjILwXFHyZ+m7Ty1dfr0ezZt2U3gnrrJTfRobJTHoXf+IbuFvFITzLrLFjwJA=="],
+    "devtools-protocol": ["devtools-protocol@0.0.1653615", "", {}, "sha512-pGVkY3T/qXxAp2nFPodwYqOevk6ncNMSmvL8QfRCx5ZWGd6Vor7AFNmyaA8Zs6uJyP1QAfjuLandCgvSix1BNA=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
@@ -37,7 +37,7 @@
 
     "modern-tar": ["modern-tar@0.7.6", "", {}, "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg=="],
 
-    "puppeteer-core": ["puppeteer-core@25.3.0", "", { "dependencies": { "@puppeteer/browsers": "3.0.6", "chromium-bidi": "16.0.1", "devtools-protocol": "0.0.1638949", "typed-query-selector": "^2.12.2", "webdriver-bidi-protocol": "0.4.2", "ws": "^8.21.0" } }, "sha512-fm+wpUr2oigH1PXZvwgATrM2tYWHMDG8ASzTEe9uukCye4X5Ldx1K5BTHPFKITrIWvQQAQ256d1NpbEveBcKjA=="],
+    "puppeteer-core": ["puppeteer-core@25.5.0", "", { "dependencies": { "@puppeteer/browsers": "3.1.0", "chromium-bidi": "17.0.2", "devtools-protocol": "0.0.1653615", "typed-query-selector": "^2.12.2", "webdriver-bidi-protocol": "0.4.2", "ws": "^8.21.1" } }, "sha512-XPNT0dQJtphqQ4I29zxlG4IIPbg1iEHAQKWuQgtMJGXjACV77pZSmJvDi51IIIfd+DTKICcopJwUx4upVQ4XbA=="],
 
     "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
@@ -49,7 +49,7 @@
 
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
-    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+    "ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "type": "module",
   "dependencies": {
     "commander": "^15.0.0",
-    "puppeteer-core": "^25.3.0"
+    "puppeteer-core": "^25.5.0"
   }
 }

--- a/scripts/test-maintainer-orchestrator-policy
+++ b/scripts/test-maintainer-orchestrator-policy
@@ -5,39 +5,29 @@ skill = File.read(File.expand_path("../skills/maintainer-orchestrator/SKILL.md",
 metadata = File.read(File.expand_path("../skills/maintainer-orchestrator/agents/openai.yaml", __dir__))
 
 requirements = {
-  "Codex app workers only" => "a worker is an owned Codex app thread, never a collaboration subagent",
-  "one project thread per repository" => "Use exactly one owned Codex app project thread per repository",
-  "root-owned skill maintenance" => "Maintain this canonical `maintainer-orchestrator` skill in the current root orchestrator session, never in a project thread or collaboration subagent.",
-  "no project task fan-out" => "project threads never create task threads",
-  "pre-spawn classification" => "Before spawning a collaboration subagent, classify the task",
-  "mutating work routing" => "Any repository task that can mutate repository, GitHub, or external state",
-  "support-only subagents" => "Use collaboration subagents only for orchestration support",
-  "subagent mutation ban" => "Collaboration subagents must never edit repository files, create commits, run implementation proof as the owner, push, mutate PRs/issues, approve workflows, merge, release, deploy, or perform live product/account proof.",
-  "preservation-first recovery" => "Snapshot and preserve its state, patches, refs, logs, and evidence; hand them to the proper Codex app thread; reconcile ownership; never discard work.",
-  "thread-owned execution" => "Project execution remains owned and performed by its Codex app thread",
-  "text is not capability" => "Thread prompts do not grant capabilities",
-  "permission propagation check" => "verify its effective permission profile",
-  "no repeated permission prompts" => "Do not retry the same denied action or repeatedly prompt the owner.",
-  "single heartbeat inspection" => "inspect the existing heartbeat first",
-  "private concurrency invariant" => "Private investigation, implementation, testing, proof, and review continue independently.",
-  "single public admission gate" => "admit no additional public action until the overlap clears",
-  "frozen means public only" => "means public-mutation-frozen only when that restriction existed before the worker crossed the public boundary",
-  "decision wait does not idle" => "Keep all other qualified private project lanes active while that answer is pending.",
-  "quota-aware concurrency" => "Use a quota-aware concurrency target, defaulting to a maximum of 8 eligible root-owned Codex app project threads",
-  "quota-health admission control" => "reduce admissions while Octopool/backend or GitHub quota alerts are active",
-  "no numeric worker filling" => "never create a worker solely to reach a number",
-  "one polling owner" => "Assign exactly one polling owner per external state.",
-  "worker exact-run watcher" => "The repository worker owns one exact-run watcher",
-  "root notification ownership" => "root reads worker state and relies on harness task-completion notifications",
-  "root coherent-wait polling ban" => "While that worker has an active coherent wait, root never polls GitHub or CI for the repository.",
-  "targeted root read" => "Root performs at most one targeted external read only when worker state is stale, terminal, or ambiguous, or when the worker reports a blocker.",
-  "Octopool read verification" => "verify `command -v gh` resolves to Octopool",
-  "real-gh boundary" => "Name real-gh explicitly only for writes or read shapes the shim does not support.",
-  "stale snapshot blocks polling" => "treat the stale snapshot as a blocker for repeated polling",
-  "exact watcher identity" => "scoped to an exact run ID or head SHA",
-  "bounded watcher backoff" => "Use its 30/60/120-second backoff or repository-native default.",
-  "no bespoke gh loops" => "Never write bespoke 30–60-second `gh` loops or poll raw GraphQL",
-  "single failure log fetch" => "After terminal failure, fetch logs once and reuse them for diagnosis",
+  "single-item work stays direct" => "Do **not** create a project worker merely because the task is nontrivial.",
+  "bounded activation" => "Use orchestration mode only when at least one is true:",
+  "persistent watch is explicit" => "Persistent portfolio watch",
+  "one project thread per repository" => "Prefer one owned Codex app project thread per repository when two or more independent items are being coordinated.",
+  "same-repository work is serial" => "process same-repository items serially unless isolation is genuinely required.",
+  "no worker fan-out" => "Workers never create or manage other workers. The hierarchy stops at root coordinator → repository worker.",
+  "support-only subagents" => "Collaboration subagents are read-only support for inventory, independent analysis, CI/status observation, or reconciliation.",
+  "subagent mutation ban" => "They do not own implementation, commits, pushes, PR mutations, merges, releases, deployments, or live proof.",
+  "no simulated worker hierarchy" => "use the normal repository workflow in the current session rather than simulating a worker hierarchy with unnecessary background jobs.",
+  "text is not capability" => "Text in a prompt does not grant filesystem, network, credential, or publication access.",
+  "preserve dirty work" => "Never switch, stash, rebase, reset, clean, delete, or overwrite dirty/non-default work merely to begin orchestration.",
+  "private work remains independent" => "Private investigation, implementation, local tests, and review may proceed independently across workers.",
+  "serialize public mutation" => "Serialize only outward-facing actions when concurrent mutation would cause ambiguity or conflict:",
+  "scope does not grant release authority" => "It does not authorize releases, version bumps, tags, package publication, destructive unique-work handling, or unrelated external-system mutations unless separately requested.",
+  "one polling owner" => "Assign one owner for each external wait.",
+  "worker exact-run watcher" => "The repository worker owns its exact CI/deploy watcher.",
+  "bounded watcher" => "Use the repository-native watcher scoped to one run ID or head SHA with bounded backoff.",
+  "root polling ban" => "it does not duplicate polling while a coherent watcher is active.",
+  "single failure log fetch" => "Fetch failed logs once and reuse them.",
+  "heartbeat only for persistent work" => "Create a recurring heartbeat only for explicit persistent portfolio/watch requests.",
+  "landing review gate" => "fresh autoreview with no accepted/actionable findings;",
+  "landing CI gate" => "exact-head CI green;",
+  "no unsolicited refill" => "Refill only when the user explicitly requested an ongoing queue.",
 }
 
 missing = requirements.reject { |_label, text| skill.include?(text) }
@@ -51,12 +41,13 @@ forbidden_fan_out = [
   "Workers may review, implement, test, and monitor concurrently",
 ]
 abort "Task-thread fan-out remains" if forbidden_fan_out.any? { |text| skill.include?(text) }
-forbidden_polling_policy = [
+forbidden_legacy_policy = [
   "Maintain a target of 30 concurrent eligible",
   "Prefer an in-turn 30–60 second sleep/poll cycle",
   "Suppress routine unchanged-poll chatter, but keep polling",
+  "Always perform a dependency-freshness check before closing a repository work batch",
 ]
-abort "Quota-amplifying polling policy remains" if forbidden_polling_policy.any? { |text| skill.include?(text) }
+abort "Legacy always-on orchestration policy remains" if forbidden_legacy_policy.any? { |text| skill.include?(text) }
 abort "Stale maintainer-orchestrator default prompt" unless metadata.include?("one Codex app thread per project") && metadata.include?("skill maintenance in the root session") && metadata.include?("collaboration subagents read-only and support-only")
 
-puts "Validated maintainer-orchestrator worker and polling boundaries."
+puts "Validated maintainer-orchestrator activation, worker, public-action, and monitoring boundaries."

--- a/skills/video-transcript-downloader/package-lock.json
+++ b/skills/video-transcript-downloader/package-lock.json
@@ -8,13 +8,13 @@
       "name": "video-transcript-downloader",
       "version": "1.0.0",
       "dependencies": {
-        "youtube-transcript-plus": "^2.0.0"
+        "youtube-transcript-plus": "^2.0.1"
       }
     },
     "node_modules/youtube-transcript-plus": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/youtube-transcript-plus/-/youtube-transcript-plus-2.0.0.tgz",
-      "integrity": "sha512-n4nnGVV3ZABnvk/sSF+W51c/+P6I23kLwwhOiYeKLeHOGfpjwCUthhoKgQk9dldJEgHCkbyJpuD3vkbBxWqDHA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/youtube-transcript-plus/-/youtube-transcript-plus-2.0.1.tgz",
+      "integrity": "sha512-rU49uSbhRJzGNGtXCfx347W2xv7hJp+WDWCuY8rdA+AVcZACi6MnRuH+2JxyUpvtZOT/dayfA/9vs2r9Zr7BjQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"

--- a/skills/video-transcript-downloader/package.json
+++ b/skills/video-transcript-downloader/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "youtube-transcript-plus": "^2.0.0"
+    "youtube-transcript-plus": "^2.0.1"
   }
 }


### PR DESCRIPTION
## Summary

- realign the maintainer-orchestrator policy guard with the bounded orchestration contract introduced by `cbdf582`, while continuing to enforce single-item routing, serial repository ownership, read-only support subagents, local-work preservation, serialized public actions, and exact-run monitoring
- update `puppeteer-core` from 25.3.0 to 25.5.0 and `youtube-transcript-plus` from 2.0.0 to 2.0.1, including both lockfiles
- move CI from Node 22 to the current LTS line, Node 24; Bun 1.3.14 and the GitHub Actions majors were already current

## Root cause

The default-branch CI failure was deterministic, not flaky. The orchestrator skill was intentionally rewritten from an always-on portfolio policy to a bounded activation model, but its exact-string guard still required 34 sentences removed by that refactor. The replacement assertions cover the new contract rather than weakening or skipping the check.

## Proof

- `scripts/test-maintainer-orchestrator-policy`
- `scripts/validate-skills`
- the complete CI smoke sequence with frozen Bun/npm installs and compiled Browser Tools binary
- Browser Tools, huge-context, fleet-maintenance, npm-auth, mac-release, and skill-cleaner test suites
- `bun audit` and nested `npm audit` (zero vulnerabilities)
- compiled Browser Tools live proof: isolated Chrome 151 on port 19222 loaded and extracted `https://example.com` through Puppeteer 25.5.0; the exact-port processes were then terminated and verified gone
- transcript live proof: the updated downloader fetched a non-empty 19,988-byte transcript from a real YouTube video
- two clean Codex autoreviews with no accepted/actionable findings

No changelog entry: the changes are CI/test/dependency maintenance and do not change the user-facing contract.
