### PR TITLE
docs: require patch-backed regression provenance

### DIFF
--- a/skills/github-deep-review/SKILL.md
+++ b/skills/github-deep-review/SKILL.md
@@ -61,11 +61,11 @@ Prefer current source and executable proof over issue comments. Treat stale comm
 
 For bug/regression reviews, include a compact `Provenance:` answer when feasible:
 
-- Use `git log -S/-G`, `git blame`, linked PRs/issues, and tests.
-- Separate commit author, merger, and current PR author when they differ.
-- Phrase as `introduced by`, `made visible by`, or `carried forward by`.
-- Include confidence: `clear`, `likely`, or `unknown`.
-- For features, docs, refactors, or untraceable bugs, write `N/A` or say what evidence is missing.
+- Use `git log -S/-G`, `git blame`, and linked PRs/issues to locate candidates, not prove introduction. Before saying `introduced by`, inspect raw parents with `git --no-replace-objects cat-file -p <sha>` and verify that `git --no-replace-objects diff --no-ext-diff --no-textconv <raw-parent> <sha> -- <path>` changed the implicated behavior, using tests/repro when feasible. A genuine root needs raw-header proof that it has no parents.
+- Blame `^sha`, porcelain `boundary`, and shallow/grafted history alone are not introduction proof. `--root` can hide boundary markers; `git show` and `rev-list --parents` can disguise a shallow boundary as a root. An available raw parent permits explicit comparison even at a shallow boundary; missing parents or an unverifiable patch require `unknown` with the gap, not inference from a subject, date, or author.
+- Separate code author, introducing PR author, merger, committer, automation trigger, and current PR author. Verify identities and triggers from explicit metadata/events; a role is not proof of causation, and an unverified identity stays unknown.
+- Use `made visible by` only for a verified trigger and `carried forward by` only for verified preexisting behavior. Apply the same evidence bar to summaries and owner hints, not just a `Provenance:` field. Include confidence: `clear`, `likely`, or `unknown`.
+- For features, docs, and refactors, write `N/A`; for untraceable bugs, report `unknown` with the missing evidence. Missing provenance does not invalidate an independently proven bug.
 
 ## Fix Quality Bar
 


### PR DESCRIPTION
## What Problem This Solves

A blame result can identify a shallow or grafted history boundary rather than the commit that introduced a behavior. Treating that result as causation can incorrectly attribute a regression to a code author, PR author, merger, or committer.

This is the shared review-guidance companion to the provenance repair motivated by [the Browser startup review](https://github.com/openclaw/openclaw/pull/132486#issuecomment-5461206719). It does not change the Browser fix or the existing bot comment.

## Why This Change Was Made

Require the actual parent-relative patch before saying `introduced by`. Raw Git parents must be inspected rather than inferred from `git show`, `rev-list`, a commit subject, or blame output. Boundary markers alone are not introduction proof; missing or unverifiable history remains `unknown`.

Keep code author, introducing PR author, merger, committer, automation trigger, and current PR author separate. `Carried forward` and `made visible` also require evidence. Unknown provenance does not invalidate an independently proven bug.

## User Impact

Reviewers receive a more accurate attribution contract without changing review, publishing, or authorization commands. Documentation only; no runtime or dependency changes.

## Evidence

- `ruby scripts/validate-skills`: 69 skills validated from this repository.
- `git diff --check`: passed before commit.
- Fresh independent Codex review through P2: scoped-clean, no findings.
- Git's raw-parent and boundary behavior was checked against upstream source and real disposable Git repositories during the owning provenance investigation.

The original review's raw blame stdout is not in the recovered evidence, so this change does not claim a specific historical checkout cause or assign a replacement introducer.
