### PR TITLE
chore(deps): refresh browser tooling and CI dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: npm
@@ -20,7 +20,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.0
 
       - name: Check shell helper syntax
         run: |

--- a/bun.lock
+++ b/bun.lock
@@ -6,14 +6,14 @@
       "name": "agent-scripts-tools",
       "dependencies": {
         "commander": "^15.0.0",
-        "puppeteer-core": "^25.5.0",
+        "puppeteer-core": "^25.9.0",
       },
     },
   },
   "packages": {
-    "@puppeteer/browsers": ["@puppeteer/browsers@3.1.0", "", { "dependencies": { "modern-tar": "^0.7.6", "yargs": "^18.0.0" }, "peerDependencies": { "proxy-agent": ">=8.0.1", "yauzl": "^2.10.0 || ^3.4.0" }, "optionalPeers": ["proxy-agent", "yauzl"], "bin": { "browsers": "lib/main-cli.js" } }, "sha512-RDLpio3fH/qrj5k4DVY6eyiN8tCS0Zovd/6jW//n605oeqkWcUjn+3k+9ZtZBnbwMpsu0F7xDIiKXvVmG5c5Bw=="],
+    "@puppeteer/browsers": ["@puppeteer/browsers@3.2.1", "", { "dependencies": { "modern-tar": "^0.8.0", "yargs": "^18.0.0" }, "peerDependencies": { "proxy-agent": ">=8.0.1", "yauzl": "^2.10.0 || ^3.4.0" }, "optionalPeers": ["proxy-agent", "yauzl"], "bin": { "browsers": "lib/main-cli.js" } }, "sha512-KDz+3qDRdBAlRlMjmKyj6dEs33YHTk/xRHEENSXq6TNnhgoU15ruSHtEBeVF6OZ9tBDY55Se4P0nFMNsipzU9A=="],
 
-    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+    "ansi-regex": ["ansi-regex@6.3.0", "", {}, "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ=="],
 
     "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
@@ -23,7 +23,7 @@
 
     "commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
 
-    "devtools-protocol": ["devtools-protocol@0.0.1653615", "", {}, "sha512-pGVkY3T/qXxAp2nFPodwYqOevk6ncNMSmvL8QfRCx5ZWGd6Vor7AFNmyaA8Zs6uJyP1QAfjuLandCgvSix1BNA=="],
+    "devtools-protocol": ["devtools-protocol@0.0.1666840", "", {}, "sha512-gCcO42XCHKEs7Ag0S7aGYsnJ7hlgrO3qderYqeiY0Eqk+0GFfuvT13IA0hHreJTa2KCdDVyGMeOhdMNmrrTjVg=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
@@ -35,11 +35,11 @@
 
     "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
 
-    "modern-tar": ["modern-tar@0.7.6", "", {}, "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg=="],
+    "modern-tar": ["modern-tar@0.8.4", "", {}, "sha512-gN54ddmyzEg10orwZ2u4OOv+bjpMWdIl5jIkodK97bMq8QBSL5c0D7YX0lT1Ooz+99S7+PvFbnxzdjgHo1r41g=="],
 
-    "puppeteer-core": ["puppeteer-core@25.5.0", "", { "dependencies": { "@puppeteer/browsers": "3.1.0", "chromium-bidi": "17.0.2", "devtools-protocol": "0.0.1653615", "typed-query-selector": "^2.12.2", "webdriver-bidi-protocol": "0.4.2", "ws": "^8.21.1" } }, "sha512-XPNT0dQJtphqQ4I29zxlG4IIPbg1iEHAQKWuQgtMJGXjACV77pZSmJvDi51IIIfd+DTKICcopJwUx4upVQ4XbA=="],
+    "puppeteer-core": ["puppeteer-core@25.9.0", "", { "dependencies": { "@puppeteer/browsers": "3.2.1", "chromium-bidi": "17.0.2", "devtools-protocol": "0.0.1666840", "typed-query-selector": "^2.12.2", "webdriver-bidi-protocol": "0.4.2", "ws": "^8.21.3" } }, "sha512-U61rCwSMha62CA/Opy6tCx2Fx+ck7ouiKnbpEApzSoLYMoEu9F71nuFpHL55vmIt33/GYm6eKZVhH2ev0nAIeg=="],
 
-    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+    "string-width": ["string-width@8.2.2", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg=="],
 
     "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
@@ -53,10 +53,14 @@
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
-    "yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
+    "yargs": ["yargs@18.1.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^8.2.1", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg=="],
 
     "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "cliui/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "type": "module",
   "dependencies": {
     "commander": "^15.0.0",
-    "puppeteer-core": "^25.5.0"
+    "puppeteer-core": "^25.9.0"
   }
 }

--- a/skills/npm/scripts/npm-auth.test.sh
+++ b/skills/npm/scripts/npm-auth.test.sh
@@ -17,13 +17,13 @@ cat >"$TEST_ROOT/bin/npm" <<'EOF'
 set -euo pipefail
 test "$PWD" = "$EXPECTED_PWD"
 test "$NPM_CONFIG_USERCONFIG" = "$EXPECTED_NPMRC"
+test "$NPM_CONFIG_REGISTRY" = "https://registry.npmjs.org/"
 if env | grep -Fq 'npm_config_//registry.npmjs.org/:_authToken='; then
   echo "npm token leaked into environment" >&2
   exit 1
 fi
-test "$1" = "--registry"
-test "$2" = "https://registry.npmjs.org/"
-test "$3" = "whoami"
+test "$#" = "1"
+test "$1" = "whoami"
 printf 'steipete\n'
 EOF
 chmod +x "$TEST_ROOT/bin/npm"


### PR DESCRIPTION
Refresh the browser helper's dependency graph and CI tools, preserving the existing Bun root / npm transcript-helper split. The compiled helper passes a real Chrome navigation and DOM evaluation. Full local checks also caught a stale npm authentication fixture; it now asserts the existing environment-based registry contract and exact command arguments, while retaining the token-isolation assertions.

## Dependency changes

| Dependency/tool | Before | After |
| --- | --- | --- |
| puppeteer-core | 25.5.0 | 25.9.0 |
| @puppeteer/browsers | 3.1.0 | 3.2.1 |
| devtools-protocol | 0.0.1653615 | 0.0.1666840 |
| modern-tar | 0.7.6 | 0.8.4 |
| yargs | 18.0.0 | 18.1.0 |
| ansi-regex | 6.2.2 | 6.3.0 |
| string-width (yargs dependency) | 7.2.0 | 8.2.2 |
| actions/setup-node | v6 | v7 |
| Bun in CI | 1.3.14 | 1.4.0 |

Regenerated `bun.lock` with `bun update --latest`. `npm update` left the transcript package manifest/lockfile unchanged. Commander 15.0.0 and youtube-transcript-plus 2.0.1 are already current; checkout v7 and setup-bun v2 already track the latest release majors. No direct dependencies were added or removed. Node 24 remains the CI compatibility baseline; local validation used Node 26.8.1 and Bun 1.4.0.

Major review: [setup-node v7](https://github.com/actions/setup-node/releases/tag/v7.0.0) migrates the action to ESM; this workflow uses supported inputs and does not rely on the removed dummy authentication variable. The transitive [string-width v8](https://github.com/sindresorhus/string-width/releases/tag/v8.0.0) requires Node 20, below our existing runtime baseline. [Puppeteer release notes](https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-core-v25.9.0) and [Bun 1.4 release notes](https://bun.com/blog/bun-v1.4) were checked. No declared dependency major was skipped.

## Local validation

```text
$ bun install --frozen-lockfile
Done! Checked 26 packages (no changes) [255.00ms]

$ bun build scripts/browser-tools.ts --compile --target bun --outfile node_modules/.deps-refresh/browser-tools
 [516ms]  bundle  309 modules
[2.582s] compile  node_modules/.deps-refresh/browser-tools

$ bun test
 18 pass
 0 fail
 16 expect() calls
Ran 18 tests across 4 files. [5.08s]

$ scripts/validate-skills
Validated 57 skill(s).

$ /bin/bash scripts/test-sync-skills
sync-skills tests: ok (Bash 3.2.57(1)-release)

$ skills/clawsweeper-status/scripts/clawsweeper-status.test.sh
PASS: high-volume snapshot, row caps/order, and bounded requests
PASS: producer-failure exited 37 with diagnostic
PASS: required-fetch-failure exited 38 with diagnostic
PASS: malformed-input exited 5 with diagnostic
PASS: renderer-failure exited 5 with diagnostic
clawsweeper-status tests passed

$ scripts/test-maintainer-orchestrator-policy
Validated maintainer-orchestrator activation, worker, public-action, and monitoring boundaries.

$ bash skills/fleet-maintenance/scripts/test-fleet-profile.sh
fleet-profile tests: ok
$ bash skills/fleet-maintenance/scripts/test-agent-cli-audit.sh
agent-cli-audit tests: ok
$ bash skills/fleet-maintenance/scripts/test-octopool-audit.sh
octopool-audit tests: ok
$ ruby skills/codex-huge-context/scripts/preflight.test.rb
codex huge-context preflight tests passed
$ bash skills/npm/scripts/npm-auth.test.sh
npm auth isolation and token handling: ok
$ env -u OP_SERVICE_ACCOUNT_TOKEN -u MOLTY_OP_SERVICE_ACCOUNT_TOKEN bash skills/release-mac-app/scripts/mac-release.test.sh
mac release 1Password tests passed
```

Shell syntax validation passed for 26 scripts. In `skills/video-transcript-downloader`, `npm ci` reported zero vulnerabilities, the dynamic import confirmed `YoutubeTranscript.fetchTranscript` is a function, and `./scripts/vtd.js transcript --help` printed its expected usage. Release tests use mock credentials/tools; inherited service credentials were removed for the fixture run. That test emits a pre-existing grep diagnostic about treating command text as a filename, but exits successfully.

The project-structure self-test passed all five checks with its documented external TypeScript prerequisite supplied through `npm exec --yes --package=typescript@6.0.3` and `NODE_PATH`, without adding a repository dependency. Follow-up for Peter: TypeScript 7.0.2 no longer exposes `createSourceFile`/`ScriptTarget`; the optional mapper produces an empty TypeScript map with it. Recommend retaining TypeScript 6 for this helper until a separate compiler-API migration is designed. This is outside the declared dependency graph and was not changed here.

## Live proof

Launched a fresh headless Chrome with `puppeteer.launch`, the installed Chrome executable, and `--remote-debugging-port=0`; closed it in `finally`. These are the actual compiled-binary commands and outputs from that session:

```text
$ node_modules/.deps-refresh/browser-tools nav https://example.com --port 52472
✓ Navigated current tab to: https://example.com
$ node_modules/.deps-refresh/browser-tools eval 'JSON.stringify({title:document.title,heading:document.querySelector("h1").textContent})' --port 52472
{"title":"Example Domain","heading":"Example Domain"}
Live compiled CLI navigation + DOM evaluation: PASS
```

The harness parsed the returned JSON and asserted both values were `Example Domain`. Chrome used a fresh temporary profile; no existing browser session was used.

## CI reasoning

Default-branch CI was green before this change: [run 33337744072](https://github.com/steipete/agent-scripts/actions/runs/33337744072). The repository has one build/test/smoke workflow and no scheduled operations/monitoring workflows. All existing jobs and assertions remain enabled. The broader local suite exceeds the workflow's current smoke coverage.

Codex autoreview completed with `scoped-clean`, no accepted/actionable findings at its requested default P0 threshold. This is internal dependency maintenance with no intentional CLI behavior change, so no changelog entry is needed. PR is for maintainer review; do not merge automatically.

PR CI is now green: [run 33368061945](https://github.com/steipete/agent-scripts/actions/runs/33368061945) passed on commit `594d91ec453199efe0ffeaa228ec9e1b1065a708`, verifying setup-node v7, Bun 1.4.0, the compiled browser helper, all existing CI tests, and transcript-helper installation/smoke checks on Ubuntu. No CI reruns or weakened checks were needed. Default `main` was not modified or merged.
