### PR TITLE
ci(codex): protect private-home auth preflight regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,12 @@ jobs:
           timeout 60s env -i HOME="$test_home" PATH="$PATH" node --test skills/npm/scripts/*.test.mjs </dev/null
           timeout 30s env -i HOME="$test_home" PATH="$PATH" /bin/bash skills/npm/scripts/npm-auth.test.sh </dev/null
 
+      - name: Test Codex context and private-home auth preflight (offline, synthetic)
+        run: |
+          test_home="$(mktemp -d)"
+          trap 'rm -rf "$test_home"' EXIT
+          timeout 60s env -i HOME="$test_home" PATH="$PATH" ruby skills/codex-huge-context/scripts/preflight.test.rb </dev/null
+
       - name: Test macOS release credential boundaries (synthetic)
         run: |
           /bin/bash skills/release-mac-app/scripts/mac-release.test.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ summary: Timeline of guardrail helper changes mirrored from Sweetistics and rela
 
 ## Unreleased
 
+- Run the Codex direct-route preflight regression suite in CI with a clean environment and temporary HOME, covering private-home auth delivery and secret-safe failures without live credentials.
+
 - Make Codex Keychain helper guidance independent of private reviewer HOME paths and add a secret-safe `--private-home` delivery diagnostic without changing reviewer isolation or provider selection.
 
 - Align shared Codex routing rules with the canonical `codex-first` skill and its launch recipe instead of stale saved-defaults guidance; preserve the model gate and isolated review workflow.


### PR DESCRIPTION
## Problem

A credential helper can succeed under the operator's HOME but fail with Keychain item-not-found under the reviewer's intentionally private HOME when it relies on implicit Keychain selection.

The owner-boundary repair and synthetic private-home diagnostic already landed in [362a562](https://github.com/steipete/agent-scripts/commit/362a562bc2e07f987e376d2c7fba48e2937be329). However, CI did not run that regression suite, so its coverage did not protect subsequent changes.

## Change

Run the existing Codex direct-route preflight suite in the smoke job with an empty environment, a fresh temporary HOME, closed stdin, and a 60-second timeout. The suite uses synthetic helpers and configuration; it needs no Keychain, account login, network access, or live credentials. Cleanup removes only the test-owned HOME.

No provider/model/tier selection, authentication wrapper, credential storage, reviewer HOME isolation, sandbox grants, or secret-scanning behavior changes.

## Verification

- Executed the exact added workflow step locally: passed.
- `actionlint .github/workflows/ci.yml`: passed.
- `git diff --check`: passed.
- Negative control in a temporary copy: removing private-home validation caused the existing suite to fail specifically with `HOME-dependent helper unexpectedly passed private-home check`.
- Actual macOS parent and private-home credential preflights passed without emitting credentials.

The synthetic CI suite protects the preflight behavior; it is not a live macOS Keychain integration test.
